### PR TITLE
ci: use snyk monitor to persist scan

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -66,6 +66,8 @@ jobs:
         uses: snyk/actions/golang@0.4.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Uses `snyk monitor` to persist the result of the snyk scan in our org (https://app.snyk.io/org/rnd_recruitment_repos/projects)