### PR TITLE
refactor(npm): custom package not found error

### DIFF
--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -39,6 +39,23 @@ func TestPackageVersion(t *testing.T) {
 			expectedBody:       "{\"error\":\"invalid version constraint\"}\n",
 		},
 		{
+			name: "package not found",
+			setup: func(tb testing.TB) (*http.Request, handler.PackageResolver) {
+				tb.Helper()
+
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:8080/package/foo/1.0.1", http.NoBody)
+				req.SetPathValue("packageName", "foo")
+				req.SetPathValue("packageVersion", "1.0.1")
+
+				resolver := mockshandler.NewMockPackageResolver(gomock.NewController(t))
+				resolver.EXPECT().ResolvePackage(gomock.Any(), "foo", gomock.Any()).Return(nil, npm.ErrPackageNotFound)
+
+				return req, resolver
+			},
+			expectedStatusCode: http.StatusNotFound,
+			expectedBody:       "{\"error\":\"package not found\"}\n",
+		},
+		{
 			name: "resolve deps failed",
 			setup: func(tb testing.TB) (*http.Request, handler.PackageResolver) {
 				tb.Helper()

--- a/internal/npm/client.go
+++ b/internal/npm/client.go
@@ -108,7 +108,11 @@ func (c *Client) fetch(req *http.Request, obj any) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusOK:
+	case http.StatusNotFound:
+		return ErrPackageNotFound
+	default:
 		var body string
 		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 			return fmt.Errorf("error response decoding of %q: %w", req.URL.String(), err)

--- a/internal/npm/client_test.go
+++ b/internal/npm/client_test.go
@@ -86,7 +86,7 @@ func TestClient_FetchPackage(t *testing.T) {
 			name: "http error response decoding error",
 			transport: fakeTransport{
 				resp: &http.Response{
-					StatusCode: http.StatusNotFound,
+					StatusCode: http.StatusBadRequest,
 					Body:       io.NopCloser(strings.NewReader(`{"error":"json error"}`)),
 				},
 			},
@@ -96,11 +96,11 @@ func TestClient_FetchPackage(t *testing.T) {
 			name: "http error response decoding success",
 			transport: fakeTransport{
 				resp: &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`"not found"`)),
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`"internal server error"`)),
 				},
 			},
-			expectedErr: "http response for \"http://localhost:8080/fake-name/fake-version\": not found",
+			expectedErr: "http response for \"http://localhost:8080/fake-name/fake-version\": internal server error",
 		},
 		{
 			name: "http response decoding error",
@@ -111,6 +111,16 @@ func TestClient_FetchPackage(t *testing.T) {
 				},
 			},
 			expectedErr: "response decoding of \"http://localhost:8080/fake-name/fake-version\": json: cannot unmarshal string into Go value of type npm.Package",
+		},
+		{
+			name: "http response package not found",
+			transport: fakeTransport{
+				resp: &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`"not found"`)),
+				},
+			},
+			expectedErr: npm.ErrPackageNotFound.Error(),
 		},
 		{
 			name: "http response decoding",
@@ -169,7 +179,7 @@ func TestClient_FetchPackageMeta(t *testing.T) {
 			name: "http error response decoding error",
 			transport: fakeTransport{
 				resp: &http.Response{
-					StatusCode: http.StatusNotFound,
+					StatusCode: http.StatusBadRequest,
 					Body:       io.NopCloser(strings.NewReader(`{"error":"json error"}`)),
 				},
 			},
@@ -179,11 +189,11 @@ func TestClient_FetchPackageMeta(t *testing.T) {
 			name: "http error response decoding success",
 			transport: fakeTransport{
 				resp: &http.Response{
-					StatusCode: http.StatusNotFound,
-					Body:       io.NopCloser(strings.NewReader(`"not found"`)),
+					StatusCode: http.StatusInternalServerError,
+					Body:       io.NopCloser(strings.NewReader(`"internal server error"`)),
 				},
 			},
-			expectedErr: "http response for \"http://localhost:8080/fake-name\": not found",
+			expectedErr: "http response for \"http://localhost:8080/fake-name\": internal server error",
 		},
 		{
 			name: "http response decoding error",
@@ -194,6 +204,16 @@ func TestClient_FetchPackageMeta(t *testing.T) {
 				},
 			},
 			expectedErr: "response decoding of \"http://localhost:8080/fake-name\": json: cannot unmarshal string into Go value of type npm.PackageMeta",
+		},
+		{
+			name: "http response package not found",
+			transport: fakeTransport{
+				resp: &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       io.NopCloser(strings.NewReader(`"not found"`)),
+				},
+			},
+			expectedErr: npm.ErrPackageNotFound.Error(),
 		},
 		{
 			name: "http response decoding",

--- a/internal/npm/errors.go
+++ b/internal/npm/errors.go
@@ -1,0 +1,7 @@
+package npm
+
+import "errors"
+
+// ErrPackageNotFound indicates the package/version is
+// not found in the registry.
+var ErrPackageNotFound = errors.New("package not found")


### PR DESCRIPTION
Creates an [npm.ErrPackageNotFound] to signals that a package cannot be found in the NPM registry.