### PR TITLE
feat: implement transitive dependencies

### DIFF
--- a/internal/handler/mocks/handler.go
+++ b/internal/handler/mocks/handler.go
@@ -43,16 +43,15 @@ func (m *MockPackageResolver) EXPECT() *MockPackageResolverMockRecorder {
 }
 
 // ResolvePackage mocks base method.
-func (m *MockPackageResolver) ResolvePackage(ctx context.Context, name string, constraint *semver.Constraints) (*npm.Package, error) {
+func (m *MockPackageResolver) ResolvePackage(ctx context.Context, constraint *semver.Constraints, npmPkg *npm.NpmPackageVersion) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResolvePackage", ctx, name, constraint)
-	ret0, _ := ret[0].(*npm.Package)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "ResolvePackage", ctx, constraint, npmPkg)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // ResolvePackage indicates an expected call of ResolvePackage.
-func (mr *MockPackageResolverMockRecorder) ResolvePackage(ctx, name, constraint any) *gomock.Call {
+func (mr *MockPackageResolverMockRecorder) ResolvePackage(ctx, constraint, npmPkg any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePackage", reflect.TypeOf((*MockPackageResolver)(nil).ResolvePackage), ctx, name, constraint)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolvePackage", reflect.TypeOf((*MockPackageResolver)(nil).ResolvePackage), ctx, constraint, npmPkg)
 }

--- a/internal/npm/package.go
+++ b/internal/npm/package.go
@@ -1,6 +1,12 @@
 package npm
 
 type (
+	NpmPackageVersion struct {
+		Name         string                        `json:"name"`
+		Version      string                        `json:"version"`
+		Dependencies map[string]*NpmPackageVersion `json:"dependencies"`
+	}
+
 	// Package contains the info of an NPM package version.
 	Package struct {
 		// Name is the name of the NPM package.

--- a/test/integration/helper_test.go
+++ b/test/integration/helper_test.go
@@ -49,7 +49,7 @@ func (a *application) start() error {
 
 	//nolint:gosec // #nosec G402
 	a.cmd = exec.Command("go", "run", "../../cmd/npmjs-deps-fetcher/...",
-		"--npm.registryUrl", a.registryURL,
+		"--npm.registryUrl", "https://registry.npmjs.org",
 		"--server.addr", appAddr)
 	a.cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 

--- a/test/integration/testdata/expect_react_16.13.0.json
+++ b/test/integration/testdata/expect_react_16.13.0.json
@@ -1,8 +1,48 @@
 {
   "dependencies": {
-    "loose-envify": "1.4.0",
-    "object-assign": "4.1.1",
-    "prop-types": "15.8.1"
+    "loose-envify": {
+      "dependencies": {
+        "js-tokens": {
+          "dependencies": {},
+          "name": "js-tokens",
+          "version": "4.0.0"
+        }
+      },
+      "name": "loose-envify",
+      "version": "1.4.0"
+    },
+    "object-assign": {
+      "dependencies": {},
+      "name": "object-assign",
+      "version": "4.1.1"
+    },
+    "prop-types": {
+      "dependencies": {
+        "loose-envify": {
+          "dependencies": {
+            "js-tokens": {
+              "dependencies": {},
+              "name": "js-tokens",
+              "version": "4.0.0"
+            }
+          },
+          "name": "loose-envify",
+          "version": "1.4.0"
+        },
+        "object-assign": {
+          "dependencies": {},
+          "name": "object-assign",
+          "version": "4.1.1"
+        },
+        "react-is": {
+          "dependencies": {},
+          "name": "react-is",
+          "version": "16.13.1"
+        }
+      },
+      "name": "prop-types",
+      "version": "15.7.2"
+    }
   },
   "name": "react",
   "version": "16.13.0"


### PR DESCRIPTION
In order to extend our vulnerability scanning feature to support child dependencies for [npm packages](https://docs.npmjs.com/cli/v6/configuring-npm/package-json) as described in #11 , this pull request updates the package service to return all nested dependencies on the internal `/package` endpoint for consumption by vulnerability service instead of just returning the versions for the first level.

It supports a `GET` request to the `/package/:name/:version` endpoint and will return a JSON structure representing the full tree of dependencies. We will always return the latest matching version of a package supported to mimic the behavior of a fresh `npm install`.

**Testing**

It can be tested locally by making a request for a package with sub-dependencies e.g. `react@16.13.0`

    curl -s http://localhost:8080/package/react/16.13.0 | jq .

**Related Ticket**

* #11 